### PR TITLE
Fix pipe function

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -68,22 +68,16 @@ class Log extends EventEmitter {
       , stderr = this.stderr()
       ;
 
-    proc.stdout.pipe(stdout, { end });
-    proc.stderr.pipe(stderr, { end });
+    proc.stdout.pipe(stdout, { end: false });
+    proc.stderr.pipe(stderr, { end: false });
 
-    let e = Promise.fromCallback((cb) => proc.on('exit', (code, sig) => cb(undefined, { code, sig })));
+    let e = Promise.fromCallback((cb) => proc.on('exit', (code, sig) => cb(undefined, { code, sig })))
+      , a = Promise.fromCallback((cb) => proc.stdout.on('end', cb))
+      , b = Promise.fromCallback((cb) => proc.stderr.on('end', cb))
+      ;
 
-    let arr = [e];
-
-    if (end) {
-      // todo [akamel] should be stdout.on('end') but that doesn't fire
-      let a = Promise.fromCallback((cb) => proc.stdout.on('end', cb))
-        , b = Promise.fromCallback((cb) => proc.stderr.on('end', cb))
-        ;
-
-      arr = [e, a, b];
-    }
-
+    let arr = [e, a, b];
+  
     return Promise
             .all(arr)
             .tap(() => {


### PR DESCRIPTION
@a7medkamel 

We were confounding the readable and writeable stream. The end flag was used incorrectly.

The biggest issue by far is that we were ending the writeable stream by sending the end flag to pipe.

As a bonus, we should always check for end of readable stream, regardless if we want to end writeable stream or not.